### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -5,23 +5,23 @@
 # Class (KEYWORD1)
 #######################################
 
-M590  KEYWORD1 M590
+M590	KEYWORD1 M590
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-begin KEYWORD2
-loop  KEYWORD2
-enableDebugSerial KEYWORD2
-initialize KEYWORD2
-getSignalStrength KEYWORD2
-beginGPRS KEYWORD2
-connectTCP  KEYWORD2
-disconnectTCP KEYWORD2
-doRequest KEYWORD2
-dns KEYWORD2
-sendAT  KEYWORD2
+begin	KEYWORD2
+loop	KEYWORD2
+enableDebugSerial	KEYWORD2
+initialize	KEYWORD2
+getSignalStrength	KEYWORD2
+beginGPRS	KEYWORD2
+connectTCP	KEYWORD2
+disconnectTCP	KEYWORD2
+doRequest	KEYWORD2
+dns	KEYWORD2
+sendAT	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords